### PR TITLE
feat: async evaluation

### DIFF
--- a/datashield/src/main/java/org/molgenis/datashield/DataShieldUtils.java
+++ b/datashield/src/main/java/org/molgenis/datashield/DataShieldUtils.java
@@ -2,6 +2,7 @@ package org.molgenis.datashield;
 
 import static java.lang.String.format;
 
+import org.molgenis.r.exceptions.RExecutionException;
 import org.rosuda.REngine.REXP;
 import org.rosuda.REngine.REXPMismatchException;
 
@@ -10,11 +11,23 @@ public class DataShieldUtils {
     return format("try(serialize({%s}, NULL))", cmd);
   }
 
-  public static byte[] createRawResponse(REXP result) throws REXPMismatchException {
+  public static byte[] createRawResponse(REXP result) {
     byte[] rawResult = new byte[0];
     if (result.isRaw()) {
-      rawResult = result.asBytes();
+      try {
+        rawResult = result.asBytes();
+      } catch (REXPMismatchException e) {
+        throw new IllegalStateException(e);
+      }
     }
     return rawResult;
+  }
+
+  public static Object asNativeJavaObject(REXP result) {
+    try {
+      return result.asNativeJavaObject();
+    } catch (REXPMismatchException e) {
+      throw new RExecutionException(e);
+    }
   }
 }

--- a/datashield/src/test/java/org/molgenis/datashield/DataShieldSessionTest.java
+++ b/datashield/src/test/java/org/molgenis/datashield/DataShieldSessionTest.java
@@ -1,18 +1,27 @@
 package org.molgenis.datashield;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.molgenis.datashield.exceptions.DataShieldSessionException;
 import org.molgenis.datashield.service.DataShieldConnectionFactory;
 import org.molgenis.r.RConnectionConsumer;
 import org.molgenis.r.exceptions.ConnectionCreationFailedException;
+import org.rosuda.REngine.REXP;
 import org.rosuda.REngine.REXPMismatchException;
 import org.rosuda.REngine.Rserve.RConnection;
 import org.rosuda.REngine.Rserve.RSession;
@@ -21,15 +30,72 @@ import org.rosuda.REngine.Rserve.RserveException;
 @ExtendWith(MockitoExtension.class)
 class DataShieldSessionTest {
 
-  private DataShieldSession rDatashieldSession;
+  private DataShieldSession dataShieldSession;
   @Mock private RConnection rConnection;
   @Mock private RSession rSession;
-  @Mock private RConnectionConsumer rConnectionConsumer;
+  @Mock private RConnectionConsumer<REXP> rConnectionConsumer;
   @Mock private DataShieldConnectionFactory connectionFactory;
+  @Mock private REXP rexp;
+  private ExecutorService executorService = Executors.newSingleThreadExecutor();
 
   @BeforeEach
   public void before() {
-    this.rDatashieldSession = new DataShieldSession(connectionFactory);
+    this.dataShieldSession = new DataShieldSession(connectionFactory, executorService);
+  }
+
+  @Test
+  void testGetRConnectionFromFactory() throws RserveException {
+    when(connectionFactory.createConnection()).thenReturn(rConnection);
+    assertSame(rConnection, dataShieldSession.getRConnection());
+  }
+
+  @Test
+  void testGetRConnectionAttachToSession() throws RserveException {
+    when(rConnection.detach()).thenReturn(rSession);
+    when(rSession.attach()).thenReturn(rConnection);
+
+    dataShieldSession.tryDetachRConnection(rConnection);
+    assertSame(rConnection, dataShieldSession.getRConnection());
+  }
+
+  @Test
+  void testGetRConnectionAttachFails() throws RserveException {
+    when(rConnection.detach()).thenReturn(rSession);
+    doThrow(new RserveException(rConnection, "Cannot connect")).when(rSession).attach();
+
+    dataShieldSession.tryDetachRConnection(rConnection);
+    assertThrows(DataShieldSessionException.class, dataShieldSession::getRConnection);
+  }
+
+  @Test
+  void testDetachFails() throws RserveException {
+    doThrow(new RserveException(rConnection, "Not connected")).when(rConnection).detach();
+
+    dataShieldSession.tryDetachRConnection(rConnection);
+  }
+
+  @Test
+  void testSchedule()
+      throws REXPMismatchException, RserveException, ExecutionException, InterruptedException {
+    when(connectionFactory.createConnection()).thenReturn(rConnection);
+    when(rConnection.detach()).thenReturn(rSession);
+    when(rConnectionConsumer.accept(rConnection)).thenReturn(rexp);
+    var result = dataShieldSession.schedule(rConnectionConsumer);
+    assertSame(rexp, result.get());
+    assertSame(rexp, dataShieldSession.getLastExecution().get());
+  }
+
+  @Test
+  void testScheduleThrowingConsumer() throws REXPMismatchException, RserveException {
+    when(connectionFactory.createConnection()).thenReturn(rConnection);
+    when(rConnection.detach()).thenReturn(rSession);
+
+    doThrow(new REXPMismatchException(rexp, "blah")).when(rConnectionConsumer).accept(rConnection);
+
+    CompletableFuture<REXP> result = dataShieldSession.schedule(rConnectionConsumer);
+
+    assertThrows(ExecutionException.class, result::get);
+    verify(rConnection).detach();
   }
 
   @SuppressWarnings("unchecked")
@@ -38,7 +104,7 @@ class DataShieldSessionTest {
     when(connectionFactory.createConnection()).thenReturn(rConnection);
     when(rConnection.detach()).thenReturn(rSession);
 
-    rDatashieldSession.execute(rConnectionConsumer);
+    dataShieldSession.execute(rConnectionConsumer);
 
     assertAll(
         () -> verify(rConnectionConsumer).accept(rConnection), () -> verify(rConnection).detach());
@@ -51,33 +117,33 @@ class DataShieldSessionTest {
     when(connectionFactory.createConnection())
         .thenThrow(new ConnectionCreationFailedException(cause));
 
-    Assertions.assertThatThrownBy(() -> rDatashieldSession.execute(rConnectionConsumer))
+    Assertions.assertThatThrownBy(() -> dataShieldSession.execute(rConnectionConsumer))
         .hasCause(cause);
   }
 
   @SuppressWarnings("unchecked")
   @Test
-  void sessionCleanup() throws REXPMismatchException, RserveException {
+  void sessionCleanup() throws RserveException {
     when(connectionFactory.createConnection()).thenReturn(rConnection);
     when(rConnection.detach()).thenReturn(rSession);
     when(rSession.attach()).thenReturn(rConnection);
 
-    rDatashieldSession.execute(rConnectionConsumer);
-    rDatashieldSession.sessionCleanup();
+    dataShieldSession.execute(rConnectionConsumer);
+    dataShieldSession.sessionCleanup();
 
     assertAll(() -> verify(rSession).attach(), () -> verify(rConnection).close());
   }
 
   @SuppressWarnings("unchecked")
   @Test
-  void sessionCleanupFails() throws REXPMismatchException, RserveException {
+  void sessionCleanupFails() throws RserveException {
     when(connectionFactory.createConnection()).thenReturn(rConnection);
     when(rConnection.detach()).thenReturn(rSession);
     when(rSession.attach()).thenThrow(new RserveException(rConnection, "foutje"));
 
-    rDatashieldSession.execute(rConnectionConsumer);
+    dataShieldSession.execute(rConnectionConsumer);
 
-    Assertions.assertThatThrownBy(() -> rDatashieldSession.sessionCleanup())
+    Assertions.assertThatThrownBy(() -> dataShieldSession.sessionCleanup())
         .hasCause(new RserveException(rConnection, "foutje"));
   }
 }

--- a/datashield/src/test/java/org/molgenis/datashield/DataShieldUtilsTest.java
+++ b/datashield/src/test/java/org/molgenis/datashield/DataShieldUtilsTest.java
@@ -1,13 +1,28 @@
 package org.molgenis.datashield;
 
 import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.molgenis.datashield.DataShieldUtils.asNativeJavaObject;
 import static org.molgenis.datashield.DataShieldUtils.createRawResponse;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.molgenis.r.exceptions.RExecutionException;
+import org.rosuda.REngine.REXP;
 import org.rosuda.REngine.REXPMismatchException;
+import org.rosuda.REngine.REXPNull;
 import org.rosuda.REngine.REXPRaw;
+import org.rosuda.REngine.REXPString;
 
+@ExtendWith(MockitoExtension.class)
 public class DataShieldUtilsTest {
+
+  @Mock REXP rexp;
+
   @Test
   public void testSerializeCommand() {
     String cmd = "meanDS(D$age";
@@ -16,10 +31,42 @@ public class DataShieldUtilsTest {
   }
 
   @Test
-  public void testCreateRawResponse() throws REXPMismatchException {
-    REXPRaw rexpDouble = new REXPRaw(new byte[0]);
+  public void testCreateRawResponse() {
+    byte[] bytes = {0x01, 0x02, 0x03};
+    REXPRaw rexpDouble = new REXPRaw(bytes);
     byte[] actual = createRawResponse(rexpDouble);
+    assertArrayEquals(bytes, actual);
+  }
+
+  @Test
+  public void testCreateRawResponseNotRaw() {
+    REXP rexp = new REXP();
+    byte[] actual = createRawResponse(rexp);
     byte[] expected = new byte[0];
     assertArrayEquals(expected, actual);
+  }
+
+  @Test
+  public void testCreateRawResponseMisbehavingREXP() throws REXPMismatchException {
+    when(rexp.isRaw()).thenReturn(true);
+    doThrow(new REXPMismatchException(rexp, "blah")).when(rexp).asBytes();
+    assertThrows(IllegalStateException.class, () -> createRawResponse(rexp));
+  }
+
+  @Test
+  public void testAsNativeJavaObjectREXPNull() throws REXPMismatchException {
+    assertEquals(null, asNativeJavaObject(new REXPNull()));
+  }
+
+  @Test
+  public void testAsNativeJavaObjectREXPDouble() throws REXPMismatchException {
+    Object actual = asNativeJavaObject(new REXPString("hello"));
+    assertArrayEquals(new String[] {"hello"}, (String[]) actual);
+  }
+
+  @Test
+  public void testAsNativeJavaObjectThrowsException() throws REXPMismatchException {
+    doThrow(new REXPMismatchException(rexp, "blah")).when(rexp).asNativeJavaObject();
+    assertThrows(RExecutionException.class, () -> asNativeJavaObject(rexp));
   }
 }

--- a/datashield/test.http
+++ b/datashield/test.http
@@ -1,0 +1,14 @@
+POST http://localhost:8080/login?username=admin&password=admin
+
+###
+POST http://localhost:8080/execute
+accept: application/json
+Content-Type: text/plain
+
+'Hello there'
+
+###
+GET http://localhost:8080/lastresult
+accept: application/json
+
+###

--- a/r/src/main/java/org/molgenis/r/service/RConfig.java
+++ b/r/src/main/java/org/molgenis/r/service/RConfig.java
@@ -1,0 +1,14 @@
+package org.molgenis.r.service;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RConfig {
+  @Bean
+  public ExecutorService executorService() {
+    return Executors.newCachedThreadPool();
+  }
+}


### PR DESCRIPTION
Use content negotiation to determine evaluate raw or not.
Use separate thread pool for evaluation of all requests.
Evaluation returns a CompletableFuture.
Session keeps last result.