### PR TITLE
feat: implement DSI methods

### DIFF
--- a/datashield/src/main/java/org/molgenis/datashield/AuthConfig.java
+++ b/datashield/src/main/java/org/molgenis/datashield/AuthConfig.java
@@ -2,9 +2,11 @@ package org.molgenis.datashield;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 
+@EnableGlobalMethodSecurity(prePostEnabled = true)
 @Configuration
 public class AuthConfig extends WebSecurityConfigurerAdapter {
 

--- a/datashield/src/main/java/org/molgenis/datashield/DataController.java
+++ b/datashield/src/main/java/org/molgenis/datashield/DataController.java
@@ -111,7 +111,7 @@ public class DataController {
   /** @return a list of (fully qualified) table identifiers available for DataSHIELD operations. */
   @GetMapping(value = "/tables", produces = APPLICATION_JSON_VALUE)
   public List<String> getTables() throws REXPMismatchException {
-    final String command = format("local(ls(%s))", TABLE_ENV);
+    final String command = format("base::local(base::ls(%s))", TABLE_ENV);
     REXP result =
         datashieldSession.execute(connection -> rExecutorService.execute(command, connection));
     return asList(result.asStrings());
@@ -128,7 +128,7 @@ public class DataController {
   @GetMapping(value = "/symbols", produces = APPLICATION_JSON_VALUE)
   public List<String> getSymbols() throws REXPMismatchException {
     REXP result =
-        datashieldSession.execute(connection -> rExecutorService.execute("ls()", connection));
+        datashieldSession.execute(connection -> rExecutorService.execute("base::ls()", connection));
     return asList(result.asStrings());
   }
 
@@ -176,7 +176,7 @@ public class DataController {
   @DeleteMapping(value = "/symbols/{symbol}")
   public void removeSymbol(
       @Valid @Pattern(regexp = "\\p{Alnum}[\\w.]*") @PathVariable String symbol) {
-    String command = format("rm(%s)", symbol);
+    String command = format("base::rm(%s)", symbol);
     datashieldSession.execute(connection -> rExecutorService.execute(command, connection));
   }
 

--- a/datashield/src/main/java/org/molgenis/datashield/DataController.java
+++ b/datashield/src/main/java/org/molgenis/datashield/DataController.java
@@ -1,18 +1,28 @@
 package org.molgenis.datashield;
 
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.molgenis.datashield.DataShieldUtils.GLOBAL_ENV;
+import static org.molgenis.datashield.DataShieldUtils.TABLE_ENV;
 import static org.molgenis.datashield.DataShieldUtils.serializeExpression;
+import static org.molgenis.r.Formatter.stringVector;
+import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.MediaType.*;
 import static org.springframework.http.ResponseEntity.created;
 import static org.springframework.http.ResponseEntity.notFound;
+import static org.springframework.http.ResponseEntity.ok;
+import static org.springframework.web.bind.annotation.RequestMethod.HEAD;
 import static org.springframework.web.servlet.support.ServletUriComponentsBuilder.fromCurrentContextPath;
 
 import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import javax.validation.Valid;
+import javax.validation.constraints.Pattern;
 import org.molgenis.datashield.pojo.DataShieldCommandDTO;
 import org.molgenis.datashield.service.DataShieldExpressionRewriter;
 import org.molgenis.datashield.service.StorageService;
@@ -20,15 +30,19 @@ import org.molgenis.r.model.RPackage;
 import org.molgenis.r.service.PackageService;
 import org.molgenis.r.service.RExecutorService;
 import org.rosuda.REngine.REXP;
+import org.rosuda.REngine.REXPMismatchException;
 import org.springframework.core.io.InputStreamResource;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.util.IdGenerator;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@Validated
 public class DataController {
-
+  public static final String SYMBOL_RE = "\\p{Alnum}[\\w.]*";
+  public static final String SYMBOL_CSV_RE = "\\p{Alnum}[\\w.]*(,\\p{Alnum}[\\w.]*)*";
   private final RExecutorService rExecutorService;
   private final DataShieldSession datashieldSession;
   private final DataShieldExpressionRewriter expressionRewriter;
@@ -52,37 +66,16 @@ public class DataController {
   }
 
   @GetMapping(value = "/lastresult", produces = APPLICATION_OCTET_STREAM_VALUE)
-  @ResponseStatus(HttpStatus.OK)
+  @ResponseStatus(OK)
   public CompletableFuture<ResponseEntity<byte[]>> lastResultRaw() {
-    return Optional.ofNullable(datashieldSession.getLastExecution())
+    return datashieldSession
+        .getLastExecution()
         .map(
             execution ->
                 execution
                     .thenApply(DataShieldUtils::createRawResponse)
                     .thenApply(ResponseEntity::ok))
         .orElse(completedFuture(notFound().build()));
-  }
-
-  @GetMapping(value = "/lastresult", produces = APPLICATION_JSON_VALUE)
-  @ResponseStatus(HttpStatus.OK)
-  public CompletableFuture<ResponseEntity<Object>> lastResultString() {
-    return Optional.ofNullable(datashieldSession.getLastExecution())
-        .map(
-            execution ->
-                execution
-                    .thenApply(DataShieldUtils::asNativeJavaObject)
-                    .thenApply(ResponseEntity::ok))
-        .orElse(completedFuture(notFound().build()));
-  }
-
-  @PostMapping(value = "/execute", consumes = TEXT_PLAIN_VALUE, produces = APPLICATION_JSON_VALUE)
-  public CompletableFuture<ResponseEntity<Object>> execute(
-      @RequestBody String expression, @RequestParam(defaultValue = "false") boolean async) {
-    String rewrittenExpression = expressionRewriter.rewriteAggregate(expression);
-    CompletableFuture<REXP> result = datashieldSession.schedule(rewrittenExpression);
-    return async
-        ? createdLastCommand()
-        : result.thenApply(DataShieldUtils::asNativeJavaObject).thenApply(ResponseEntity::ok);
   }
 
   @PostMapping(
@@ -117,51 +110,74 @@ public class DataController {
 
   /** @return a list of (fully qualified) table identifiers available for DataSHIELD operations. */
   @GetMapping(value = "/tables", produces = APPLICATION_JSON_VALUE)
-  public List<String> getTables() {
-    // TODO implement
-    return Collections.emptyList();
+  public List<String> getTables() throws REXPMismatchException {
+    final String command = format("local(ls(%s))", TABLE_ENV);
+    REXP result =
+        datashieldSession.execute(connection -> rExecutorService.execute(command, connection));
+    return asList(result.asStrings());
   }
 
-  /** @return true if the the table exists and is available for DataSHIELD operations. */
-  @GetMapping("/exists/{entityTypeId}")
-  public boolean exists(@PathVariable String entityTypeId) {
-    return false;
+  /** @return OK if the the table exists and is available for DataSHIELD operations. */
+  @RequestMapping(value = "/tables/{tableId}", method = HEAD)
+  public ResponseEntity<Void> tableExists(@PathVariable String tableId)
+      throws REXPMismatchException {
+    return getTables().contains(tableId) ? ok().build() : notFound().build();
   }
 
   /** @return a list of assigned symbols */
   @GetMapping(value = "/symbols", produces = APPLICATION_JSON_VALUE)
-  public List<String> getSymbols() {
-    // TODO implement
-    return Collections.emptyList();
+  public List<String> getSymbols() throws REXPMismatchException {
+    REXP result =
+        datashieldSession.execute(connection -> rExecutorService.execute("ls()", connection));
+    return asList(result.asStrings());
+  }
+
+  /** Copy (variables of) a table into a symbol. */
+  @PostMapping(value = "/symbols/{symbol}")
+  public ResponseEntity<Void> loadTable(
+      @Valid @Pattern(regexp = SYMBOL_RE) @PathVariable String symbol,
+      @Valid @Pattern(regexp = SYMBOL_RE) @RequestParam String table,
+      @Valid @Pattern(regexp = SYMBOL_CSV_RE) @RequestParam(required = false) String variables)
+      throws REXPMismatchException, ExecutionException, InterruptedException {
+    if (!getTables().contains(table)) {
+      return notFound().build();
+    }
+    String expression = table;
+    if (variables != null) {
+      String[] split = variables.split(",");
+      expression = format("%s[,%s]", table, stringVector(split));
+    }
+    expression = format("base::local(%s, envir = %s)", expression, TABLE_ENV);
+    datashieldSession.assign(symbol, expression).get();
+    return ok().build();
   }
 
   /** Assign the result of the evaluation of an expression to a symbol. */
-  @PostMapping(
-      value = "/symbols",
-      consumes = APPLICATION_JSON_VALUE,
-      produces = APPLICATION_JSON_VALUE)
-  public CompletableFuture<Object> assignSymbol(
-      @RequestBody String symbol, @RequestBody String expression) {
-    // TODO implement
-    return null;
+  @PostMapping(value = "/symbols/{symbol}", consumes = TEXT_PLAIN_VALUE)
+  public CompletableFuture<ResponseEntity<Void>> assignSymbol(
+      @Valid @Pattern(regexp = "\\p{Alnum}[\\w.]*") @PathVariable String symbol,
+      @RequestBody String expression,
+      @RequestParam(defaultValue = "false") boolean async) {
+    String rewrittenExpression = expressionRewriter.rewriteAssign(expression);
+    CompletableFuture<Void> result = datashieldSession.assign(symbol, rewrittenExpression);
+    return async ? createdLastCommand() : result.thenApply(ResponseEntity::ok);
   }
 
-  /** Assign the result of the evaluation of an expression to a symbol. */
-  @PostMapping(
-      value = "/symbols",
-      consumes = APPLICATION_JSON_VALUE,
-      produces = APPLICATION_OCTET_STREAM_VALUE)
-  public CompletableFuture<byte[]> assignSymbolRaw(
-      @RequestBody String symbol, @RequestBody String expression) {
-    // TODO implement
-    return null;
+  /** Debug an expression */
+  @PreAuthorize("hasRole('ROLE_SU')")
+  @PostMapping(value = "/debug", consumes = TEXT_PLAIN_VALUE, produces = APPLICATION_JSON_VALUE)
+  public Object debug(@RequestBody String expression) throws REXPMismatchException {
+    REXP result =
+        datashieldSession.execute(connection -> rExecutorService.execute(expression, connection));
+    return result.asNativeJavaObject();
   }
 
   /** Removes a symbol, making the assigned data inaccessible */
   @DeleteMapping(value = "/symbols/{symbol}")
-  @ResponseStatus(HttpStatus.OK)
-  public void removeSymbol(@PathVariable String symbol) {
-    // TODO implement
+  public void removeSymbol(
+      @Valid @Pattern(regexp = "\\p{Alnum}[\\w.]*") @PathVariable String symbol) {
+    String command = format("rm(%s)", symbol);
+    datashieldSession.execute(connection -> rExecutorService.execute(command, connection));
   }
 
   /**
@@ -187,7 +203,7 @@ public class DataController {
    * @param id the id of the saved workspace
    */
   @DeleteMapping(value = "/workspaces/{id}")
-  @ResponseStatus(HttpStatus.OK)
+  @ResponseStatus(OK)
   public void removeWorkspace(@PathVariable String id) {
     // TODO implement
   }
@@ -195,7 +211,7 @@ public class DataController {
   @PostMapping(value = "/save-workspace", produces = TEXT_PLAIN_VALUE)
   public String save() {
     UUID saveId = idGenerator.generateId();
-    String objectname = String.format("%s/.RData", saveId.toString());
+    String objectname = format("%s/.RData", saveId.toString());
     datashieldSession.execute(
         connection -> {
           rExecutorService.saveWorkspace(
@@ -205,14 +221,25 @@ public class DataController {
     return saveId.toString();
   }
 
+  @PreAuthorize("hasRole('ROLE_' + #folder + '_RESEARCHER')")
+  @PostMapping(value = "/load-tables/{folder}/{name}")
+  public void loadTables(@PathVariable String folder, @PathVariable String name) {
+    String objectName = format("%s/%s.RData", folder, name);
+    load(objectName, TABLE_ENV);
+  }
+
   @PostMapping(value = "/load-workspace/{saveId}")
-  public void loadWorkspace(@PathVariable String saveId) {
-    UUID uuid = UUID.fromString(saveId);
-    String objectname = String.format("%s/.RData", uuid.toString());
+  public void loadUserWorkspace(@PathVariable String saveId) {
+    String objectName = format("%s/.RData", UUID.fromString(saveId).toString());
+    load(objectName, GLOBAL_ENV);
+  }
+
+  private void load(String objectName, String environment) {
     datashieldSession.execute(
         connection -> {
-          InputStream inputStream = storageService.load(objectname);
-          rExecutorService.loadWorkspace(connection, new InputStreamResource(inputStream));
+          InputStream inputStream = storageService.load(objectName);
+          rExecutorService.loadWorkspace(
+              connection, new InputStreamResource(inputStream), environment);
           return null;
         });
   }

--- a/datashield/src/main/java/org/molgenis/datashield/DataShieldUtils.java
+++ b/datashield/src/main/java/org/molgenis/datashield/DataShieldUtils.java
@@ -7,8 +7,12 @@ import org.rosuda.REngine.REXP;
 import org.rosuda.REngine.REXPMismatchException;
 
 public class DataShieldUtils {
+
+  public static final String TABLE_ENV = ".DSTableEnv";
+  public static final String GLOBAL_ENV = ".GlobalEnv";
+
   public static String serializeExpression(String cmd) {
-    return format("try(serialize({%s}, NULL))", cmd);
+    return format("try(base::serialize({%s}, NULL))", cmd);
   }
 
   public static byte[] createRawResponse(REXP result) {

--- a/datashield/src/main/java/org/molgenis/datashield/pojo/DataShieldCommand.java
+++ b/datashield/src/main/java/org/molgenis/datashield/pojo/DataShieldCommand.java
@@ -34,14 +34,14 @@ public class DataShieldCommand<T> {
     IN_PROGRESS
   }
 
-  public DataShieldCommand(String expression) {
-    this(expression, systemUTC());
+  public DataShieldCommand(String expression, boolean withResult) {
+    this(expression, withResult, systemUTC());
   }
 
   // For test purposes, allow the clock to be mocked
-  DataShieldCommand(String expression, Clock clock) {
+  DataShieldCommand(String expression, boolean withResult, Clock clock) {
     this.expression = expression;
-    this.withResult = true;
+    this.withResult = withResult;
     this.createDate = clock.instant();
     this.id = UUID.randomUUID();
     this.clock = clock;

--- a/datashield/src/main/java/org/molgenis/datashield/service/DataShieldConnectionFactoryImpl.java
+++ b/datashield/src/main/java/org/molgenis/datashield/service/DataShieldConnectionFactoryImpl.java
@@ -1,5 +1,8 @@
 package org.molgenis.datashield.service;
 
+import static java.lang.String.format;
+import static org.molgenis.datashield.DataShieldUtils.TABLE_ENV;
+
 import java.util.Map.Entry;
 import org.molgenis.datashield.DataShieldOptions;
 import org.molgenis.r.RConnectionFactory;
@@ -24,7 +27,7 @@ public class DataShieldConnectionFactoryImpl implements DataShieldConnectionFact
   public RConnection createConnection() {
     try {
       RConnection connection = rConnectionFactory.createConnection();
-      loadSessionContextPackages(connection);
+      createTableEnvironment(connection);
       setDataShieldOptions(connection);
       return connection;
     } catch (RserveException cause) {
@@ -34,12 +37,11 @@ public class DataShieldConnectionFactoryImpl implements DataShieldConnectionFact
 
   private void setDataShieldOptions(RConnection con) throws RserveException {
     for (Entry<String, String> option : dataShieldOptions.getValue().entrySet()) {
-      con.eval(String.format("options(%s = %s)", option.getKey(), option.getValue()));
+      con.eval(format("base::options(%s = %s)", option.getKey(), option.getValue()));
     }
   }
 
-  private void loadSessionContextPackages(RConnection connection) throws RserveException {
-    connection.eval("library(dsBase)");
-    connection.eval("library(readr)");
+  private void createTableEnvironment(RConnection connection) throws RserveException {
+    connection.eval(format("%s <- base::new.env()", TABLE_ENV));
   }
 }

--- a/datashield/src/main/resources/application.yml
+++ b/datashield/src/main/resources/application.yml
@@ -10,26 +10,31 @@ spring:
     user:
       name: admin
       password: admin
+      roles:
+        - DIABETES_RESEARCHER
+        - SU
 minio:
   url: http://localhost
   port: 9000
   access-key: molgenis
   secret-key: molgenis
   bucket: datashield
+logging:
+  level:
+    org.molgenis: DEBUG
 ---
 spring:
   profiles: (development | test)
 datashield:
   options:
-    default:
-      nfilter:
-        string: 0
-        kNN: 0
-        tab: 0
-        stringShort: 0
-        noise: 0
-        levels: 0
-        glm: 0
-        subset: 0
+    nfilter:
+      string: 0
+      kNN: 0
+      tab: 0
+      stringShort: 0
+      noise: 0
+      levels: 0
+      glm: 0
+      subset: 0
     datashield:
       privacyLevel: 0

--- a/datashield/src/test/java/org/molgenis/datashield/DataControllerTest.java
+++ b/datashield/src/test/java/org/molgenis/datashield/DataControllerTest.java
@@ -99,7 +99,8 @@ class DataControllerTest {
   @WithMockUser
   void getGetTables() throws Exception {
     mockDatashieldExecuteSessionConsumer();
-    when(rExecutorService.execute("local(ls(.DSTableEnv))", rConnection)).thenReturn(rexp);
+    when(rExecutorService.execute("base::local(base::ls(.DSTableEnv))", rConnection))
+        .thenReturn(rexp);
     when(rexp.asStrings()).thenReturn(new String[] {"datashield.PATIENT", "datashield.SAMPLE"});
 
     mockMvc
@@ -113,7 +114,8 @@ class DataControllerTest {
   @WithMockUser
   void testTableExists() throws Exception {
     mockDatashieldExecuteSessionConsumer();
-    when(rExecutorService.execute("local(ls(.DSTableEnv))", rConnection)).thenReturn(rexp);
+    when(rExecutorService.execute("base::local(base::ls(.DSTableEnv))", rConnection))
+        .thenReturn(rexp);
     when(rexp.asStrings()).thenReturn(new String[] {"datashield.PATIENT", "datashield.SAMPLE"});
 
     mockMvc.perform(head("/tables/datashield.PATIENT")).andExpect(status().isOk());
@@ -123,7 +125,8 @@ class DataControllerTest {
   @WithMockUser
   void testTableNotFound() throws Exception {
     mockDatashieldExecuteSessionConsumer();
-    when(rExecutorService.execute("local(ls(.DSTableEnv))", rConnection)).thenReturn(rexp);
+    when(rExecutorService.execute("base::local(base::ls(.DSTableEnv))", rConnection))
+        .thenReturn(rexp);
     when(rexp.asStrings()).thenReturn(new String[] {});
 
     mockMvc.perform(head("/tables/datashield.PATIENT")).andExpect(status().isNotFound());
@@ -133,7 +136,7 @@ class DataControllerTest {
   @WithMockUser
   void getGetSymbols() throws Exception {
     mockDatashieldExecuteSessionConsumer();
-    when(rExecutorService.execute("ls()", rConnection)).thenReturn(rexp);
+    when(rExecutorService.execute("base::ls()", rConnection)).thenReturn(rexp);
     when(rexp.asStrings()).thenReturn(new String[] {"D"});
 
     mockMvc
@@ -150,7 +153,7 @@ class DataControllerTest {
 
     mockMvc.perform(delete("/symbols/D")).andExpect(status().isOk());
 
-    verify(rExecutorService).execute("rm(D)", rConnection);
+    verify(rExecutorService).execute("base::rm(D)", rConnection);
   }
 
   @Test
@@ -336,7 +339,8 @@ class DataControllerTest {
   void testLoadTableDoesNotExist() throws Exception {
     mockDatashieldExecuteSessionConsumer();
 
-    when(rExecutorService.execute("local(ls(.DSTableEnv))", rConnection)).thenReturn(rexp);
+    when(rExecutorService.execute("base::local(base::ls(.DSTableEnv))", rConnection))
+        .thenReturn(rexp);
     when(rexp.asStrings()).thenReturn(new String[] {});
 
     mockMvc.perform(post("/symbols/D?table=datashield.PATIENT")).andExpect(status().isNotFound());
@@ -347,7 +351,8 @@ class DataControllerTest {
   void testLoadTable() throws Exception {
     mockDatashieldExecuteSessionConsumer();
 
-    when(rExecutorService.execute("local(ls(.DSTableEnv))", rConnection)).thenReturn(rexp);
+    when(rExecutorService.execute("base::local(base::ls(.DSTableEnv))", rConnection))
+        .thenReturn(rexp);
     when(rexp.asStrings()).thenReturn(new String[] {"datashield.PATIENT"});
 
     when(datashieldSession.assign("D", "base::local(datashield.PATIENT, envir = .DSTableEnv)"))
@@ -361,7 +366,8 @@ class DataControllerTest {
   void testLoadTableWithVariables() throws Exception {
     mockDatashieldExecuteSessionConsumer();
 
-    when(rExecutorService.execute("local(ls(.DSTableEnv))", rConnection)).thenReturn(rexp);
+    when(rExecutorService.execute("base::local(base::ls(.DSTableEnv))", rConnection))
+        .thenReturn(rexp);
     when(rexp.asStrings()).thenReturn(new String[] {"datashield.PATIENT"});
 
     when(datashieldSession.assign(

--- a/datashield/src/test/java/org/molgenis/datashield/DataControllerTest.java
+++ b/datashield/src/test/java/org/molgenis/datashield/DataControllerTest.java
@@ -12,7 +12,9 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.http.MediaType.APPLICATION_OCTET_STREAM;
 import static org.springframework.http.MediaType.TEXT_PLAIN;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.head;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -23,6 +25,7 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,8 +38,8 @@ import org.molgenis.r.RConnectionConsumer;
 import org.molgenis.r.model.RPackage;
 import org.molgenis.r.service.PackageService;
 import org.molgenis.r.service.RExecutorServiceImpl;
+import org.rosuda.REngine.REXP;
 import org.rosuda.REngine.REXPDouble;
-import org.rosuda.REngine.REXPNull;
 import org.rosuda.REngine.REXPRaw;
 import org.rosuda.REngine.Rserve.RConnection;
 import org.rosuda.REngine.Rserve.RFileInputStream;
@@ -78,6 +81,7 @@ class DataControllerTest {
   @MockBean private DataShieldExpressionRewriter expressionRewriter;
   @Mock private RFileInputStream inputStream;
   @Mock private RConnection rConnection;
+  @Mock private REXP rexp;
 
   @Test
   @WithMockUser
@@ -93,29 +97,76 @@ class DataControllerTest {
 
   @Test
   @WithMockUser
+  void getGetTables() throws Exception {
+    mockDatashieldExecuteSessionConsumer();
+    when(rExecutorService.execute("local(ls(.DSTableEnv))", rConnection)).thenReturn(rexp);
+    when(rexp.asStrings()).thenReturn(new String[] {"datashield.PATIENT", "datashield.SAMPLE"});
+
+    mockMvc
+        .perform(get("/tables"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(APPLICATION_JSON))
+        .andExpect(content().json("[\"datashield.PATIENT\",\"datashield.SAMPLE\"]"));
+  }
+
+  @Test
+  @WithMockUser
+  void testTableExists() throws Exception {
+    mockDatashieldExecuteSessionConsumer();
+    when(rExecutorService.execute("local(ls(.DSTableEnv))", rConnection)).thenReturn(rexp);
+    when(rexp.asStrings()).thenReturn(new String[] {"datashield.PATIENT", "datashield.SAMPLE"});
+
+    mockMvc.perform(head("/tables/datashield.PATIENT")).andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser
+  void testTableNotFound() throws Exception {
+    mockDatashieldExecuteSessionConsumer();
+    when(rExecutorService.execute("local(ls(.DSTableEnv))", rConnection)).thenReturn(rexp);
+    when(rexp.asStrings()).thenReturn(new String[] {});
+
+    mockMvc.perform(head("/tables/datashield.PATIENT")).andExpect(status().isNotFound());
+  }
+
+  @Test
+  @WithMockUser
+  void getGetSymbols() throws Exception {
+    mockDatashieldExecuteSessionConsumer();
+    when(rExecutorService.execute("ls()", rConnection)).thenReturn(rexp);
+    when(rexp.asStrings()).thenReturn(new String[] {"D"});
+
+    mockMvc
+        .perform(get("/symbols"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(APPLICATION_JSON))
+        .andExpect(content().json("[\"D\"]"));
+  }
+
+  @Test
+  @WithMockUser
+  void deleteSymbol() throws Exception {
+    mockDatashieldExecuteSessionConsumer();
+
+    mockMvc.perform(delete("/symbols/D")).andExpect(status().isOk());
+
+    verify(rExecutorService).execute("rm(D)", rConnection);
+  }
+
+  @Test
+  @WithMockUser
   void testGetLastResultNoResult() throws Exception {
-    MvcResult result = mockMvc.perform(get("/lastresult").accept(APPLICATION_JSON)).andReturn();
+    MvcResult result =
+        mockMvc.perform(get("/lastresult").accept(APPLICATION_OCTET_STREAM)).andReturn();
     mockMvc.perform(asyncDispatch(result)).andExpect(status().isNotFound());
   }
 
   @Test
   @WithMockUser
-  void testGetLastResultJson() throws Exception {
-    when(datashieldSession.getLastExecution()).thenReturn(completedFuture(new REXPDouble(12.34)));
-
-    MvcResult result = mockMvc.perform(get("/lastresult").accept(APPLICATION_JSON)).andReturn();
-    mockMvc
-        .perform(asyncDispatch(result))
-        .andExpect(status().isOk())
-        .andExpect(content().contentType(APPLICATION_JSON))
-        .andExpect(content().json("[12.34]"));
-  }
-
-  @Test
-  @WithMockUser
-  void testGetLastResultRaw() throws Exception {
+  void testGetLastResult() throws Exception {
     byte[] bytes = {0x0, 0x1, 0x2};
-    when(datashieldSession.getLastExecution()).thenReturn(completedFuture(new REXPRaw(bytes)));
+    when(datashieldSession.getLastExecution())
+        .thenReturn(Optional.of(completedFuture(new REXPRaw(bytes))));
 
     MvcResult result =
         mockMvc.perform(get("/lastresult").accept(APPLICATION_OCTET_STREAM)).andReturn();
@@ -189,79 +240,12 @@ class DataControllerTest {
         .perform(post("/load-workspace/00000000-0000-007b-0000-0000000001c8"))
         .andExpect(status().isOk());
 
-    verify(rExecutorService).loadWorkspace(eq(rConnection), any());
+    verify(rExecutorService).loadWorkspace(eq(rConnection), any(), eq(".GlobalEnv"));
   }
 
   @Test
   @WithMockUser
-  void testExecuteAsync() throws Exception {
-    when(datashieldSession.schedule("meanDS(D$age)"))
-        .thenReturn(completedFuture(new REXPDouble(36.6)));
-
-    MvcResult result =
-        mockMvc
-            .perform(
-                post("/execute?async=true")
-                    .contentType(TEXT_PLAIN)
-                    .content("meanDS(D$age)")
-                    .accept(APPLICATION_JSON))
-            .andReturn();
-    mockMvc
-        .perform(asyncDispatch(result))
-        .andExpect(status().isCreated())
-        .andExpect(header().string("Location", "http://localhost/lastcommand"))
-        .andExpect(content().string(""));
-  }
-
-  @Test
-  @WithMockUser
-  void testExecuteDoubleResult() throws Exception {
-    String expression = "meanDS(D$age)";
-    String rewrittenExpression = "dsBase::meanDS(D$age)";
-    when(expressionRewriter.rewriteAggregate(expression)).thenReturn(rewrittenExpression);
-    when(datashieldSession.schedule(rewrittenExpression))
-        .thenReturn(completedFuture(new REXPDouble(36.6)));
-
-    MvcResult result =
-        mockMvc
-            .perform(
-                post("/execute")
-                    .contentType(TEXT_PLAIN)
-                    .content(expression)
-                    .accept(APPLICATION_JSON))
-            .andReturn();
-    mockMvc
-        .perform(asyncDispatch(result))
-        .andExpect(status().isOk())
-        .andExpect(content().string("[36.6]"));
-  }
-
-  @Test
-  @WithMockUser
-  void testExecuteNullResult() throws Exception {
-    String expression = "meanDS(D$age)";
-    String rewrittenExpression = "dsBase::meanDS(D$age)";
-    when(expressionRewriter.rewriteAggregate(expression)).thenReturn(rewrittenExpression);
-    when(datashieldSession.schedule(rewrittenExpression))
-        .thenReturn(completedFuture(new REXPNull()));
-
-    MvcResult result =
-        mockMvc
-            .perform(
-                post("/execute")
-                    .contentType(TEXT_PLAIN)
-                    .accept(APPLICATION_JSON)
-                    .content(expression))
-            .andReturn();
-    mockMvc
-        .perform(asyncDispatch(result))
-        .andExpect(status().isOk())
-        .andExpect(content().string(""));
-  }
-
-  @Test
-  @WithMockUser
-  void testExecuteRawResult() throws Exception {
+  void testExecute() throws Exception {
     String expression = "meanDS(D$age)";
     String rewrittenExpression = "dsBase::meanDS(D$age)";
     when(expressionRewriter.rewriteAggregate(expression)).thenReturn(rewrittenExpression);
@@ -277,6 +261,133 @@ class DataControllerTest {
                 .contentType(TEXT_PLAIN)
                 .content(expression))
         .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser
+  void testExecuteAsync() throws Exception {
+    when(datashieldSession.schedule("meanDS(D$age)"))
+        .thenReturn(completedFuture(new REXPDouble(36.6)));
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                post("/execute?async=true")
+                    .contentType(TEXT_PLAIN)
+                    .content("meanDS(D$age)")
+                    .accept(APPLICATION_OCTET_STREAM))
+            .andReturn();
+    mockMvc
+        .perform(asyncDispatch(result))
+        .andExpect(status().isCreated())
+        .andExpect(header().string("Location", "http://localhost/lastcommand"))
+        .andExpect(content().string(""));
+  }
+
+  @Test
+  @WithMockUser
+  void testAssign() throws Exception {
+    String expression = "meanDS(D$age)";
+    String rewrittenExpression = "dsBase::meanDS(D$age)";
+    when(expressionRewriter.rewriteAssign(expression)).thenReturn(rewrittenExpression);
+
+    CompletableFuture<Void> assignment = new CompletableFuture<>();
+    when(datashieldSession.assign("E", rewrittenExpression)).thenReturn(assignment);
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                post("/symbols/E")
+                    .accept(APPLICATION_OCTET_STREAM)
+                    .contentType(TEXT_PLAIN)
+                    .content(expression))
+            .andReturn();
+
+    assignment.complete(null);
+    mockMvc.perform(asyncDispatch(result)).andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser
+  void testAssignAsync() throws Exception {
+    String expression = "meanDS(D$age)";
+    String rewrittenExpression = "dsBase::meanDS(D$age)";
+    when(expressionRewriter.rewriteAssign(expression)).thenReturn(rewrittenExpression);
+
+    when(datashieldSession.assign("E", rewrittenExpression)).thenReturn(new CompletableFuture<>());
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                post("/symbols/E?async=true")
+                    .contentType(TEXT_PLAIN)
+                    .content("meanDS(D$age)")
+                    .accept(APPLICATION_OCTET_STREAM))
+            .andReturn();
+    mockMvc
+        .perform(asyncDispatch(result))
+        .andExpect(status().isCreated())
+        .andExpect(header().string("Location", "http://localhost/lastcommand"))
+        .andExpect(content().string(""));
+  }
+
+  @Test
+  @WithMockUser
+  void testLoadTableDoesNotExist() throws Exception {
+    mockDatashieldExecuteSessionConsumer();
+
+    when(rExecutorService.execute("local(ls(.DSTableEnv))", rConnection)).thenReturn(rexp);
+    when(rexp.asStrings()).thenReturn(new String[] {});
+
+    mockMvc.perform(post("/symbols/D?table=datashield.PATIENT")).andExpect(status().isNotFound());
+  }
+
+  @Test
+  @WithMockUser
+  void testLoadTable() throws Exception {
+    mockDatashieldExecuteSessionConsumer();
+
+    when(rExecutorService.execute("local(ls(.DSTableEnv))", rConnection)).thenReturn(rexp);
+    when(rexp.asStrings()).thenReturn(new String[] {"datashield.PATIENT"});
+
+    when(datashieldSession.assign("D", "base::local(datashield.PATIENT, envir = .DSTableEnv)"))
+        .thenReturn(completedFuture(null));
+
+    mockMvc.perform(post("/symbols/D?table=datashield.PATIENT")).andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser
+  void testLoadTableWithVariables() throws Exception {
+    mockDatashieldExecuteSessionConsumer();
+
+    when(rExecutorService.execute("local(ls(.DSTableEnv))", rConnection)).thenReturn(rexp);
+    when(rexp.asStrings()).thenReturn(new String[] {"datashield.PATIENT"});
+
+    when(datashieldSession.assign(
+            "D", "base::local(datashield.PATIENT[,c(\"age\")], envir = .DSTableEnv)"))
+        .thenReturn(completedFuture(null));
+
+    mockMvc
+        .perform(post("/symbols/D?table=datashield.PATIENT&variables=age"))
+        .andExpect(status().isOk());
+  }
+
+  @WithMockUser
+  @Test
+  public void testLoadTibblesNotAResearcher() throws Exception {
+    mockMvc.perform(post("/load-tables/DIABETES/patient")).andExpect(status().isForbidden());
+  }
+
+  @WithMockUser(roles = {"DIABETES_RESEARCHER"})
+  @Test
+  public void testLoadTibbles() throws Exception {
+    mockDatashieldExecuteSessionConsumer();
+    when(storageService.load("DIABETES/patient.RData")).thenReturn(inputStream);
+
+    mockMvc.perform(post("/load-tables/DIABETES/patient")).andExpect(status().isOk());
+
+    verify(rExecutorService).loadWorkspace(eq(rConnection), any(), eq(".DSTableEnv"));
   }
 
   @SuppressWarnings("unchecked")

--- a/datashield/src/test/java/org/molgenis/datashield/DataShieldSessionTest.java
+++ b/datashield/src/test/java/org/molgenis/datashield/DataShieldSessionTest.java
@@ -86,9 +86,9 @@ class DataShieldSessionTest {
   void testSchedule() throws RserveException, ExecutionException, InterruptedException {
     when(connectionFactory.createConnection()).thenReturn(rConnection);
     when(rConnection.detach()).thenReturn(rSession);
-    when(rExecutorService.execute("ls()", rConnection)).thenReturn(rexp);
+    when(rExecutorService.execute("base::ls()", rConnection)).thenReturn(rexp);
 
-    var result = dataShieldSession.schedule("ls()");
+    var result = dataShieldSession.schedule("base::ls()");
 
     assertSame(rexp, result.get());
     assertSame(result, dataShieldSession.getLastExecution().get());
@@ -110,13 +110,13 @@ class DataShieldSessionTest {
   void getLastCommand() throws RserveException, ExecutionException, InterruptedException {
     when(connectionFactory.createConnection()).thenReturn(rConnection);
     when(rConnection.detach()).thenReturn(rSession);
-    when(rExecutorService.execute("ls()", rConnection)).thenReturn(rexp);
+    when(rExecutorService.execute("base::ls()", rConnection)).thenReturn(rexp);
     // schedule and await completion
-    dataShieldSession.schedule("ls()").get();
+    dataShieldSession.schedule("base::ls()").get();
 
     DataShieldCommandDTO command = dataShieldSession.getLastCommand().get();
 
-    assertEquals("ls()", command.expression());
+    assertEquals("base::ls()", command.expression());
     assertEquals(COMPLETED, command.status());
   }
 
@@ -124,10 +124,10 @@ class DataShieldSessionTest {
   void testScheduleThrowingConsumer() throws REXPMismatchException, RserveException {
     when(connectionFactory.createConnection()).thenReturn(rConnection);
     when(rConnection.detach()).thenReturn(rSession);
-    when(rExecutorService.execute("ls()", rConnection))
+    when(rExecutorService.execute("base::ls()", rConnection))
         .thenThrow(new RExecutionException(new REXPMismatchException(rexp, "access")));
 
-    CompletableFuture<REXP> result = dataShieldSession.schedule("ls()");
+    CompletableFuture<REXP> result = dataShieldSession.schedule("base::ls()");
 
     assertThrows(ExecutionException.class, result::get);
     verify(rConnection).detach();

--- a/datashield/src/test/java/org/molgenis/datashield/DataShieldSessionTest.java
+++ b/datashield/src/test/java/org/molgenis/datashield/DataShieldSessionTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.molgenis.datashield.pojo.DataShieldCommand.DataShieldCommandStatus.COMPLETED;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -90,7 +91,19 @@ class DataShieldSessionTest {
     var result = dataShieldSession.schedule("ls()");
 
     assertSame(rexp, result.get());
-    assertSame(result, dataShieldSession.getLastExecution());
+    assertSame(result, dataShieldSession.getLastExecution().get());
+  }
+
+  @Test
+  void testAssign() throws RserveException, ExecutionException, InterruptedException {
+    when(connectionFactory.createConnection()).thenReturn(rConnection);
+    when(rConnection.detach()).thenReturn(rSession);
+
+    dataShieldSession.assign("D", "1:5").get();
+
+    verify(rExecutorService).execute("D <- 1:5", rConnection);
+    assertEquals(COMPLETED, dataShieldSession.getLastCommand().get().status());
+    assertEquals(Optional.empty(), dataShieldSession.getLastExecution());
   }
 
   @Test

--- a/datashield/src/test/java/org/molgenis/datashield/DataShieldUtilsTest.java
+++ b/datashield/src/test/java/org/molgenis/datashield/DataShieldUtilsTest.java
@@ -27,7 +27,7 @@ public class DataShieldUtilsTest {
   public void testSerializeCommand() {
     String cmd = "meanDS(D$age";
     String serializedCommand = DataShieldUtils.serializeExpression(cmd);
-    assertEquals("try(serialize({meanDS(D$age}, NULL))", serializedCommand);
+    assertEquals("try(base::serialize({meanDS(D$age}, NULL))", serializedCommand);
   }
 
   @Test

--- a/datashield/src/test/java/org/molgenis/datashield/pojo/DataShieldCommandTest.java
+++ b/datashield/src/test/java/org/molgenis/datashield/pojo/DataShieldCommandTest.java
@@ -33,7 +33,7 @@ class DataShieldCommandTest {
   @BeforeEach
   void setUp() {
     when(clock.instant()).thenReturn(createDate);
-    command = new DataShieldCommand("expression", clock);
+    command = new DataShieldCommand("expression", true, clock);
   }
 
   @Test

--- a/datashield/src/test/java/org/molgenis/datashield/service/DataShieldConnectionFactoryImplTest.java
+++ b/datashield/src/test/java/org/molgenis/datashield/service/DataShieldConnectionFactoryImplTest.java
@@ -37,9 +37,8 @@ class DataShieldConnectionFactoryImplTest {
   void testGetNewConnection() throws RserveException {
     doReturn(rConnection).when(rConnectionFactory).createConnection();
     when(dataShieldOptions.getValue()).thenReturn(ImmutableMap.of("a", "80.0"));
-    when(rConnection.eval("library(dsBase)")).thenReturn(new REXPNull());
-    when(rConnection.eval("library(readr)")).thenReturn(new REXPNull());
-    when(rConnection.eval("options(a = 80.0)")).thenReturn(new REXPNull());
+    when(rConnection.eval(".DSTableEnv <- base::new.env()")).thenReturn(new REXPNull());
+    when(rConnection.eval("base::options(a = 80.0)")).thenReturn(new REXPNull());
 
     assertEquals(rConnection, dataShieldConnectionFactory.createConnection());
   }

--- a/datashield/test.http
+++ b/datashield/test.http
@@ -1,18 +1,68 @@
 POST http://localhost:8080/login?username=admin&password=admin
 
 ###
-POST http://localhost:8080/execute?async=true
-accept: application/json
-Content-Type: text/plain
-
-'Hello there'
+POST http://localhost:8080/load-tables/DIABETES/patient
 
 ###
-GET http://localhost:8080/lastresult
-accept: application/json
+POST http://localhost:8080/load-tables/GECKO/patient
+
+###
+GET http://localhost:8080/tables
+
+###
+HEAD http://localhost:8080/tables/datashield.PATIENT
+
+###
+POST http://localhost:8080/symbols/D?table=datashield.PATIENT
+
+###
+POST http://localhost:8080/symbols/D?table=datashield.PATIENT&variables=age,name
+
+###
+POST http://localhost:8080/execute
+Accept: application/octet-stream
+Content-Type: text/plain
+
+colnames(D)
+
+###
+GET http://localhost:8080/symbols
+
+###
+POST http://localhost:8080/execute
+Accept: application/octet-stream
+Content-Type: text/plain
+
+meanDS(D$age)
+
+###
+DELETE http://localhost:8080/symbols/D
+
+###
+POST http://localhost:8080/symbols/D?async=true
+Content-Type: text/plain
+
+0:5
+
+###
+POST http://localhost:8080/debug
+Content-Type: text/plain
+
+dsBase::meanDS(D)$EstimatedMean
+
+###
+POST http://localhost:8080/execute?async=true
+Accept: application/octet-stream
+Content-Type: text/plain
+
+meanDS(D)
 
 ###
 GET http://localhost:8080/lastcommand
 accept: application/json
+
+###
+GET http://localhost:8080/lastresult
+accept: application/octet-stream
 
 ###

--- a/r/src/main/java/org/molgenis/r/service/RExecutorService.java
+++ b/r/src/main/java/org/molgenis/r/service/RExecutorService.java
@@ -11,5 +11,5 @@ public interface RExecutorService {
 
   void saveWorkspace(RConnection connection, Consumer<InputStream> inputStreamConsumer);
 
-  void loadWorkspace(RConnection connection, Resource resource);
+  void loadWorkspace(RConnection connection, Resource resource, String environment);
 }

--- a/r/src/main/java/org/molgenis/r/service/RExecutorServiceImpl.java
+++ b/r/src/main/java/org/molgenis/r/service/RExecutorServiceImpl.java
@@ -1,5 +1,7 @@
 package org.molgenis.r.service;
 
+import static java.lang.String.format;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.function.Consumer;
@@ -44,11 +46,12 @@ public class RExecutorServiceImpl implements RExecutorService {
   }
 
   @Override
-  public void loadWorkspace(RConnection connection, Resource resource) {
-    LOGGER.debug("Load workspace");
+  public void loadWorkspace(RConnection connection, Resource resource, String environment) {
+    LOGGER.debug("Load workspace into {}", environment);
     try {
       copyFile(resource, ".RData", connection);
-      connection.eval("base::load(file='.RData')");
+      connection.eval(format("base::load(file='.RData', envir=%s)", environment));
+      connection.eval("base::unlink('.RData')");
     } catch (IOException | RserveException e) {
       throw new RExecutionException(e);
     }

--- a/r/src/test/java/org/molgenis/r/service/RExecutorServiceImplTest.java
+++ b/r/src/test/java/org/molgenis/r/service/RExecutorServiceImplTest.java
@@ -60,9 +60,10 @@ class RExecutorServiceImplTest {
     when(rConnection.createFile(".RData")).thenReturn(rFileOutputStream);
     Resource resource = new InMemoryResource("Hello");
 
-    executorService.loadWorkspace(rConnection, resource);
+    executorService.loadWorkspace(rConnection, resource, ".TibbleEnv");
 
-    verify(rConnection).eval("base::load(file='.RData')");
+    verify(rConnection).eval("base::load(file='.RData', envir=.TibbleEnv)");
+    verify(rConnection).eval("base::unlink('.RData')");
   }
 
   @Test


### PR DESCRIPTION
Removes json execution endpoints, adds endpoints to:
* Load tables workspace from minio into environment
* List tables
* Assign symbol from table
* Assign symbol from expression, also async
* List symbols
* Delete symbol
* Debug any expression (role SU only)